### PR TITLE
feat: add `without` function

### DIFF
--- a/proto/rulo.proto
+++ b/proto/rulo.proto
@@ -170,6 +170,7 @@ message Query {
 
     // Document Manipulation
     Pluck pluck = 22;
+    Without without = 23;
 
     // Schema & Data Modeling
     TableCreate table_create = 14;
@@ -223,6 +224,11 @@ message Skip {
 message Count { Query source = 1; }
 
 message Pluck {
+  Query source = 1;
+  repeated FieldRef fields = 2;
+}
+
+message Without {
   Query source = 1;
   repeated FieldRef fields = 2;
 }
@@ -345,6 +351,7 @@ message QueryResult {
     SkipResult skip = 8;
     CountResult count = 9;
     PluckResult pluck = 19;
+    WithoutResult without = 20;
 
     InsertResult insert = 10;
     DeleteResult delete = 11;
@@ -398,12 +405,19 @@ message CountResult { uint64 count = 1; }
 
 message PluckResult {
   oneof result {
-    Datum document = 1; // Single document result (from get-like sources)
-    PluckCollectionResult collection = 2; // Multiple documents result
+    Datum document = 1;
+    CollectionResult collection = 2;
   }
 }
 
-message PluckCollectionResult {
+message WithoutResult {
+  oneof result {
+    Datum document = 1;
+    CollectionResult collection = 2;
+  }
+}
+
+message CollectionResult {
   repeated Datum documents = 1;
   Cursor cursor = 2;
 }

--- a/sdk/typescript/__tests__/without.test.ts
+++ b/sdk/typescript/__tests__/without.test.ts
@@ -1,0 +1,531 @@
+import { Connection } from '../src/connection';
+import { r, RQuery } from '../src/query';
+
+// Mock the Connection class
+jest.mock('../src/connection');
+
+describe('Without Operations', () => {
+  let mockConnection: jest.Mocked<Connection>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnection = {
+      query: jest.fn(),
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      isConnected: jest.fn().mockReturnValue(true),
+      on: jest.fn(),
+      off: jest.fn()
+    } as any;
+  });
+
+  describe('without() basic functionality', () => {
+    it('should create without query with single field', () => {
+      const query = r.db('mydb').table('users').without('password');
+
+      expect(query).toBeInstanceOf(RQuery);
+      expect(query._query.without).toBeDefined();
+      expect(query._query.without!.fields).toEqual([{ path: ['password'], separator: '.' }]);
+      expect(query._query.without!.source).toEqual({
+        table: {
+          table: {
+            database: { name: 'mydb' },
+            name: 'users'
+          }
+        }
+      });
+    });
+
+    it('should create without query with multiple fields', () => {
+      const query = r.db('mydb').table('users').without('password', 'ssn', 'secret');
+
+      expect(query._query.without).toBeDefined();
+      expect(query._query.without!.fields).toEqual([
+        { path: ['password'], separator: '.' },
+        { path: ['ssn'], separator: '.' },
+        { path: ['secret'], separator: '.' }
+      ]);
+      expect(query._query.without!.source).toEqual({
+        table: {
+          table: {
+            database: { name: 'mydb' },
+            name: 'users'
+          }
+        }
+      });
+    });
+
+    it('should execute without query successfully', async () => {
+      const mockResult = {
+        items: [
+          { id: '1', name: 'John', email: 'john@example.com' },
+          { id: '2', name: 'Jane', email: 'jane@example.com' }
+        ]
+      };
+
+      mockConnection.query.mockResolvedValue(mockResult);
+
+      const query = r.db('mydb').table('users').without('password');
+      const result = await query.run(mockConnection);
+
+      expect(mockConnection.query).toHaveBeenCalledWith({
+        without: {
+          source: {
+            table: {
+              table: {
+                database: { name: 'mydb' },
+                name: 'users'
+              }
+            }
+          },
+          fields: [{ path: ['password'], separator: '.' }]
+        }
+      });
+      expect(result).toBeDefined();
+    });
+
+    it('should require at least one field', () => {
+      // TypeScript would prevent calling without() with no arguments
+      // Instead, verify that without requires at least one field
+      const query = r.db('mydb').table('users').without('password');
+      expect(query._query.without).toBeDefined();
+      expect(query._query.without!.fields).toEqual([{ path: ['password'], separator: '.' }]);
+    });
+  });
+
+  describe('without() chaining from different sources', () => {
+    it('should chain without from table scan', () => {
+      const query = r.db('mydb').table('users').without('password');
+
+      expect(query._query.without!.source).toEqual({
+        table: {
+          table: {
+            database: { name: 'mydb' },
+            name: 'users'
+          }
+        }
+      });
+    });
+
+    it('should chain without from getAll', () => {
+      const query = r.db('mydb').table('users').getAll('user1', 'user2').without('password', 'ssn');
+
+      expect(query._query.without!.source).toEqual({
+        getAll: {
+          source: {
+            table: {
+              table: {
+                database: { name: 'mydb' },
+                name: 'users'
+              }
+            }
+          },
+          keys: [{ string: 'user1' }, { string: 'user2' }]
+        }
+      });
+      expect(query._query.without!.fields).toHaveLength(2);
+    });
+
+    it('should chain without from filter', () => {
+      const query = r
+        .db('mydb')
+        .table('users')
+        .filter({ active: true })
+        .without('internal_notes', 'password');
+
+      expect(query._query.without!.source).toEqual({
+        filter: {
+          source: {
+            table: {
+              table: {
+                database: { name: 'mydb' },
+                name: 'users'
+              }
+            }
+          },
+          predicate: expect.any(Object)
+        }
+      });
+      expect(query._query.without!.fields).toHaveLength(2);
+    });
+
+    it('should chain without from orderBy', () => {
+      const query = r.db('mydb').table('users').orderBy('name').without('created_at', 'updated_at');
+
+      expect(query._query.without!.source).toEqual({
+        orderBy: {
+          source: {
+            table: {
+              table: {
+                database: { name: 'mydb' },
+                name: 'users'
+              }
+            }
+          },
+          fields: expect.any(Array)
+        }
+      });
+      expect(query._query.without!.fields).toHaveLength(2);
+    });
+  });
+
+  describe('without() chaining to other operations', () => {
+    it('should allow chaining filter after without', () => {
+      const query = r.db('mydb').table('users').without('password').filter({ status: 'active' });
+
+      expect(query._query.filter!.source!.without).toBeDefined();
+      expect(query._query.filter!.source!.without!.fields).toHaveLength(1);
+    });
+
+    it('should allow chaining orderBy after without', () => {
+      const query = r.db('mydb').table('users').without('password', 'ssn').orderBy('name');
+
+      expect(query._query.orderBy!.source!.without).toBeDefined();
+      expect(query._query.orderBy!.source!.without!.fields).toHaveLength(2);
+    });
+
+    it('should allow chaining limit after without', () => {
+      const query = r.db('mydb').table('users').without('internal_data').limit(10);
+
+      expect(query._query.limit!.source!.without).toBeDefined();
+      expect(query._query.limit!.count).toBe(10);
+    });
+
+    it('should allow chaining skip after without', () => {
+      const query = r.db('mydb').table('users').without('metadata', 'temp_data').skip(5);
+
+      expect(query._query.skip!.source!.without).toBeDefined();
+      expect(query._query.skip!.count).toBe(5);
+      expect(query._query.skip!.source!.without!.fields).toHaveLength(2);
+    });
+
+    it('should allow chaining count after without', () => {
+      const query = r.db('mydb').table('users').without('sensitive_info').count();
+
+      expect(query._query.count!.source!.without).toBeDefined();
+    });
+  });
+
+  describe('without() with complex queries', () => {
+    it('should work in complex query chains', () => {
+      const query = r
+        .db('mydb')
+        .table('users')
+        .filter({ status: 'active' })
+        .without('password', 'ssn', 'internal_notes')
+        .orderBy('name')
+        .limit(5);
+
+      expect(query._query.limit!.source!.orderBy!.source!.without).toBeDefined();
+      expect(query._query.limit!.source!.orderBy!.source!.without!.fields).toHaveLength(3);
+    });
+
+    it('should handle nested field names', () => {
+      const query = r.db('mydb').table('users').without('user.password', 'metadata.internal');
+
+      expect(query._query.without!.fields).toEqual([
+        { path: ['user', 'password'], separator: '.' },
+        { path: ['metadata', 'internal'], separator: '.' }
+      ]);
+    });
+  });
+
+  describe('without() with pagination', () => {
+    it('should handle without queries with cursor options', async () => {
+      const firstPageResult = {
+        items: [
+          { id: '1', name: 'John', email: 'john@example.com' },
+          { id: '2', name: 'Jane', email: 'jane@example.com' }
+        ],
+        cursor: { startKey: 'cursor_token_123' }
+      };
+
+      const secondPageResult = {
+        items: [
+          { id: '3', name: 'Bob', email: 'bob@example.com' },
+          { id: '4', name: 'Alice', email: 'alice@example.com' }
+        ]
+      };
+
+      mockConnection.query
+        .mockResolvedValueOnce(firstPageResult)
+        .mockResolvedValueOnce(secondPageResult);
+
+      const firstPage = await r
+        .db('mydb')
+        .table('users')
+        .without('password', 'ssn')
+        .limit(2)
+        .run(mockConnection);
+
+      const firstPageItems = await firstPage.toArray();
+      expect(firstPageItems).toEqual(firstPageResult.items);
+      expect(firstPage.getCurrentStartKey()).toEqual(firstPageResult.cursor.startKey);
+
+      const secondPage = await r
+        .db('mydb')
+        .table('users')
+        .without('password', 'ssn')
+        .limit(2)
+        .run(mockConnection);
+
+      const secondPageItems = await secondPage.toArray();
+      expect(secondPageItems).toEqual(secondPageResult.items);
+    });
+
+    it('should handle large result sets with without', async () => {
+      const mockResult = {
+        items: Array.from({ length: 1000 }, (_, i) => ({
+          id: `${i}`,
+          name: `User${i}`,
+          email: `user${i}@example.com`
+        }))
+      };
+
+      mockConnection.query.mockResolvedValue(mockResult);
+
+      const result = await r.db('mydb').table('users').without('temp_data').run(mockConnection);
+
+      const resultItems = await result.toArray();
+      expect(resultItems).toEqual(mockResult.items);
+    });
+  });
+
+  describe('without() with typed interfaces', () => {
+    interface User {
+      id: string;
+      name: string;
+      email: string;
+      password: string;
+      ssn: string;
+      phone?: string;
+      address?: string;
+    }
+
+    interface UserPublic {
+      id: string;
+      name: string;
+      email: string;
+      phone?: string;
+      address?: string;
+    }
+
+    it('should work with typed table queries', () => {
+      const query = r.db('mydb').table<User>('users').without('password');
+
+      expect(query).toBeInstanceOf(RQuery);
+      expect(query._query.without).toBeDefined();
+    });
+
+    it('should maintain type information through without', () => {
+      const query = r.db('mydb').table<User>('users').without('password', 'ssn');
+
+      expect(query).toBeInstanceOf(RQuery);
+      expect(query._query.without!.fields).toHaveLength(2);
+    });
+
+    it('should support type override with explicit result type', () => {
+      const query = r.db('mydb').table<User>('users').without<UserPublic>('password', 'ssn');
+
+      expect(query).toBeInstanceOf(RQuery);
+      expect(query._query.without!.fields).toHaveLength(2);
+    });
+
+    it('should support type override with array syntax', () => {
+      const query = r.db('mydb').table('users').without<UserPublic>('password', 'ssn');
+
+      expect(query).toBeInstanceOf(RQuery);
+      expect(query._query.without!.fields).toHaveLength(2);
+    });
+  });
+
+  describe('without() error handling', () => {
+    it('should handle without errors', async () => {
+      mockConnection.query.mockRejectedValue(new Error('Network error'));
+
+      const query = r.db('mydb').table('users').without('password');
+
+      await expect(query.run(mockConnection)).rejects.toThrow('Network error');
+    });
+
+    it('should handle table not found errors in without', async () => {
+      mockConnection.query.mockRejectedValue(new Error('Table not found'));
+
+      const query = r.db('mydb').table('nonexistent_table').without('password');
+
+      await expect(query.run(mockConnection)).rejects.toThrow('Table not found');
+    });
+
+    it('should handle database not found errors in without', async () => {
+      mockConnection.query.mockRejectedValue(new Error('Database not found'));
+
+      const query = r.db('nonexistent_db').table('users').without('password');
+
+      await expect(query.run(mockConnection)).rejects.toThrow('Database not found');
+    });
+
+    it('should handle connection errors during without execution', async () => {
+      const disconnectedConnection = {
+        ...mockConnection,
+        isConnected: jest.fn().mockReturnValue(false),
+        query: jest.fn().mockRejectedValue(new Error('Connection closed'))
+      } as any;
+
+      const query = r.db('mydb').table('users').without('password');
+
+      await expect(query.run(disconnectedConnection)).rejects.toThrow('Connection closed');
+    });
+  });
+
+  describe('without() edge cases', () => {
+    it('should handle duplicate field names', () => {
+      const query = r.db('mydb').table('users').without('password', 'password', 'ssn');
+
+      expect(query._query.without!.fields).toHaveLength(3);
+      expect(query._query.without!.fields).toEqual([
+        { path: ['password'], separator: '.' },
+        { path: ['password'], separator: '.' },
+        { path: ['ssn'], separator: '.' }
+      ]);
+    });
+
+    it('should handle empty table with without', async () => {
+      const mockResult = { items: [] };
+      mockConnection.query.mockResolvedValue(mockResult);
+
+      const query = r.db('mydb').table('empty_table').without('password');
+      const result = await query.run(mockConnection);
+
+      const resultItems = await result.toArray();
+      expect(resultItems).toEqual(mockResult.items);
+    });
+
+    it('should handle very long field names', () => {
+      const longFieldName = 'a'.repeat(1000);
+      const query = r.db('mydb').table('users').without(longFieldName);
+
+      expect(query._query.without!.fields[0].path).toEqual([longFieldName]);
+    });
+
+    it('should handle special characters in field names', () => {
+      const query = r
+        .db('mydb')
+        .table('users')
+        .without('field-with-dashes', 'field_with_underscores', 'field with spaces');
+
+      expect(query._query.without!.fields).toHaveLength(3);
+      expect(query._query.without!.fields[0].path).toEqual(['field-with-dashes']);
+      expect(query._query.without!.fields[1].path).toEqual(['field_with_underscores']);
+      expect(query._query.without!.fields[2].path).toEqual(['field with spaces']);
+    });
+  });
+
+  describe('without() performance scenarios', () => {
+    it('should handle without with large number of fields', () => {
+      const manyFields = Array.from({ length: 100 }, (_, i) => `field_${i}`);
+      const query = r
+        .db('mydb')
+        .table('users')
+        .without(...manyFields);
+
+      expect(query._query.without!.fields).toHaveLength(100);
+      manyFields.forEach((field, index) => {
+        expect(query._query.without!.fields[index].path).toEqual([field]);
+      });
+    });
+
+    it('should work with without on indexed fields', async () => {
+      const mockResult = {
+        items: [{ id: '1', name: 'John', email: 'john@example.com', status: 'active' }]
+      };
+      mockConnection.query.mockResolvedValue(mockResult);
+
+      const query = r
+        .db('mydb')
+        .table('users')
+        .filter({ status: 'active' })
+        .without('password', 'ssn');
+
+      const result = await query.run(mockConnection);
+      const resultItems = await result.toArray();
+      expect(resultItems).toEqual(mockResult.items);
+    });
+  });
+
+  describe('without() with multiple without operations', () => {
+    it('should handle multiple without operations (last wins)', () => {
+      const query = r.db('mydb').table('users').without('password').without('ssn', 'secret');
+
+      // The second without should replace the first
+      expect(query._query.without!.fields).toHaveLength(2);
+      expect(query._query.without!.fields).toEqual([
+        { path: ['ssn'], separator: '.' },
+        { path: ['secret'], separator: '.' }
+      ]);
+    });
+  });
+
+  describe('without() with custom separator', () => {
+    it('should support custom separator with array syntax', () => {
+      const query = r
+        .db('mydb')
+        .table('users')
+        .without(['password', 'user->profile->bio'], { separator: '->' });
+
+      expect(query._query.without!.fields).toEqual([
+        { path: ['password'], separator: '->' },
+        { path: ['user', 'profile', 'bio'], separator: '->' }
+      ]);
+    });
+
+    it('should support custom separator with array syntax (pipe)', () => {
+      const query = r
+        .db('mydb')
+        .table('users')
+        .without(['password', 'metadata|internal'], { separator: '|' });
+
+      expect(query._query.without!.fields).toEqual([
+        { path: ['password'], separator: '|' },
+        { path: ['metadata', 'internal'], separator: '|' }
+      ]);
+    });
+
+    it('should default to dot separator when not specified', () => {
+      const query = r.db('mydb').table('users').without('password', 'user.profile');
+
+      expect(query._query.without!.fields).toEqual([
+        { path: ['password'], separator: '.' },
+        { path: ['user', 'profile'], separator: '.' }
+      ]);
+    });
+
+    it('should handle complex nested paths with custom separator', () => {
+      const query = r
+        .db('mydb')
+        .table('users')
+        .without(['user::profile::private::ssn', 'system::internal::debug'], {
+          separator: '::'
+        });
+
+      expect(query._query.without!.fields).toEqual([
+        { path: ['user', 'profile', 'private', 'ssn'], separator: '::' },
+        { path: ['system', 'internal', 'debug'], separator: '::' }
+      ]);
+    });
+
+    it('should handle single field with custom separator', () => {
+      const query = r.db('mydb').table('users').without(['password'], { separator: '|' });
+
+      expect(query._query.without!.fields).toEqual([{ path: ['password'], separator: '|' }]);
+    });
+
+    it('should ignore separator when field has no nested parts', () => {
+      const query = r.db('mydb').table('users').without(['password', 'ssn'], { separator: '::' });
+
+      expect(query._query.without!.fields).toEqual([
+        { path: ['password'], separator: '::' },
+        { path: ['ssn'], separator: '::' }
+      ]);
+    });
+  });
+});

--- a/sdk/typescript/src/connection.ts
+++ b/sdk/typescript/src/connection.ts
@@ -366,6 +366,27 @@ export class Connection extends EventEmitter {
       }
     }
 
+    if (queryResult.without) {
+      // Handle new WithoutResult structure with oneof result
+      if (queryResult.without.document) {
+        // Single document result
+        return {
+          result: this.convertDatum(queryResult.without.document),
+          metadata: resultMetadata
+        };
+      } else if (queryResult.without.collection) {
+        // Collection result with cursor
+        return this.convertArrayResult(
+          queryResult.without.collection.documents,
+          queryResult.without.collection.cursor,
+          resultMetadata
+        );
+      } else {
+        // Fallback for backwards compatibility
+        return this.convertArrayResult([], undefined, resultMetadata);
+      }
+    }
+
     // Handle operation results
     if (queryResult.insert) {
       return {

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -463,6 +463,7 @@ export class Cursor<T> implements AsyncIterable<T> {
       'getAll',
       'count',
       'pluck',
+      'without',
       'insert',
       'update',
       'delete',

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -84,6 +84,25 @@ impl From<&DatumObject> for Document {
     }
 }
 
+impl From<&Datum> for Document {
+    fn from(datum: &Datum) -> Self {
+        match &datum.value {
+            Some(datum::Value::Object(obj)) => obj.fields.clone(),
+            _ => HashMap::new(),
+        }
+    }
+}
+
+impl From<&Document> for Datum {
+    fn from(doc: &Document) -> Self {
+        Datum {
+            value: Some(datum::Value::Object(DatumObject {
+                fields: doc.clone(),
+            })),
+        }
+    }
+}
+
 impl std::fmt::Display for FieldRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.path.join(&self.separator))

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -350,6 +350,18 @@ impl Evaluator {
                     .await
             }
 
+            PlanNode::Without { source, fields, .. } => {
+                let source_result = Box::pin(self.execute_plan(source)).await?;
+                self.query_processor
+                    .without_documents_streaming(
+                        source_result,
+                        self.cursor_context.clone(),
+                        fields,
+                        &mut self.stats,
+                    )
+                    .await
+            }
+
             // Subqueries
             PlanNode::Subquery { query, .. } => Box::pin(self.execute_plan(query)).await,
         }

--- a/src/planner/builder.rs
+++ b/src/planner/builder.rs
@@ -55,6 +55,7 @@ impl PlanBuilder {
 
             // Document Manipulation
             Some(query::Kind::Pluck(pluck_query)) => self.build_pluck_query(pluck_query),
+            Some(query::Kind::Without(without_query)) => self.build_without_query(without_query),
 
             // Schema & Data Modeling
             Some(query::Kind::DatabaseCreate(create_db)) => Ok(PlanNode::CreateDatabase {
@@ -354,6 +355,19 @@ impl PlanBuilder {
         Ok(PlanNode::Pluck {
             source: Box::new(source_plan),
             fields: pluck_query.fields.clone(),
+            cost,
+        })
+    }
+
+    /// Build a plan for a without query
+    fn build_without_query(&mut self, without_query: &Without) -> PlanResult<PlanNode> {
+        let source_plan = self.build_query_internal(without_query.source.as_ref().ok_or(
+            PlanError::InvalidExpression("Without missing source".to_string()),
+        )?)?;
+        let cost = source_plan.cost();
+        Ok(PlanNode::Without {
+            source: Box::new(source_plan),
+            fields: without_query.fields.clone(),
             cost,
         })
     }

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -92,7 +92,8 @@ impl Explainer {
             | PlanNode::Limit { source, .. }
             | PlanNode::Skip { source, .. }
             | PlanNode::Count { source, .. }
-            | PlanNode::Pluck { source, .. } => {
+            | PlanNode::Pluck { source, .. }
+            | PlanNode::Without { source, .. } => {
                 self.explain_node(source, depth + 1, nodes);
             }
             PlanNode::Subquery { query, .. } => {
@@ -333,6 +334,17 @@ impl Explainer {
             PlanNode::Count { .. } => ("Count".to_string(), vec![]),
             PlanNode::Pluck { fields, .. } => (
                 "Pluck".to_string(),
+                vec![(
+                    "Fields".to_string(),
+                    fields
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                )],
+            ),
+            PlanNode::Without { fields, .. } => (
+                "Without".to_string(),
                 vec![(
                     "Fields".to_string(),
                     fields

--- a/tests/integration_without.rs
+++ b/tests/integration_without.rs
@@ -1,0 +1,730 @@
+mod common;
+
+use common::*;
+use rulodb::ast::proto;
+
+#[tokio::test]
+async fn test_without_basic() {
+    let query_id = "test-without-basic-001";
+    let database_name = &generate_unique_name("test_db_without_basic");
+    let table_name = &generate_unique_name("test_table_without_basic");
+
+    println!(
+        "Testing basic without operation, ID: {query_id}, database: {database_name}, table: {table_name}"
+    );
+
+    // Connect to the running server
+    let mut stream = connect_to_server()
+        .await
+        .expect("Failed to connect to server. Make sure the server is running on 127.0.0.1:6090");
+
+    // Setup: Create database and table
+    let db_create_query = create_database_create_query(database_name);
+    let db_create_envelope = create_envelope(&format!("{query_id}-db-create"), &db_create_query);
+    let db_create_response = send_envelope_to_server(&mut stream, &db_create_envelope)
+        .await
+        .expect("Failed to send database create envelope");
+    validate_response_envelope(&db_create_response, &format!("{query_id}-db-create"))
+        .expect("Database create response validation failed");
+
+    let table_create_query = create_table_create_query(database_name, table_name);
+    let table_create_envelope =
+        create_envelope(&format!("{query_id}-table-create"), &table_create_query);
+    let table_create_response = send_envelope_to_server(&mut stream, &table_create_envelope)
+        .await
+        .expect("Failed to send table create envelope");
+    validate_response_envelope(&table_create_response, &format!("{query_id}-table-create"))
+        .expect("Table create response validation failed");
+
+    // Insert test data with sensitive fields
+    let documents = vec![
+        create_datum_object(vec![
+            ("id", create_string_datum("user1")),
+            ("name", create_string_datum("Alice")),
+            ("email", create_string_datum("alice@example.com")),
+            ("password", create_string_datum("secret123")),
+            ("ssn", create_string_datum("123-45-6789")),
+            ("phone", create_string_datum("555-1234")),
+        ]),
+        create_datum_object(vec![
+            ("id", create_string_datum("user2")),
+            ("name", create_string_datum("Bob")),
+            ("email", create_string_datum("bob@example.com")),
+            ("password", create_string_datum("secret456")),
+            ("ssn", create_string_datum("987-65-4321")),
+            ("phone", create_string_datum("555-5678")),
+        ]),
+    ];
+
+    let insert_query = create_insert_query(database_name, table_name, documents);
+    let insert_envelope = create_envelope(&format!("{query_id}-insert"), &insert_query);
+    let insert_response = send_envelope_to_server(&mut stream, &insert_envelope)
+        .await
+        .expect("Failed to send insert envelope");
+    validate_response_envelope(&insert_response, &format!("{query_id}-insert"))
+        .expect("Insert response validation failed");
+
+    // Test without single field (remove password)
+    let without_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec!["password".to_string()],
+            separator: ".".to_string(),
+        }],
+    );
+
+    let without_envelope = create_envelope(&format!("{query_id}-without-single"), &without_query);
+    let without_response = send_envelope_to_server(&mut stream, &without_envelope)
+        .await
+        .expect("Failed to send without envelope");
+
+    let without_result =
+        decode_response_payload(&without_response).expect("Failed to decode without response");
+
+    // Verify the result structure
+    if let Some(proto::datum::Value::Array(array)) = &without_result.value {
+        assert_eq!(array.items.len(), 2, "Expected 2 documents in result");
+
+        for doc in &array.items {
+            if let Some(proto::datum::Value::Object(obj)) = &doc.value {
+                // Password field should be removed
+                assert!(
+                    !obj.fields.contains_key("password"),
+                    "Password field should be removed"
+                );
+                // Other fields should remain
+                assert!(obj.fields.contains_key("name"), "Name field should remain");
+                assert!(
+                    obj.fields.contains_key("email"),
+                    "Email field should remain"
+                );
+                assert!(obj.fields.contains_key("ssn"), "SSN field should remain");
+                assert!(
+                    obj.fields.contains_key("phone"),
+                    "Phone field should remain"
+                );
+            } else {
+                panic!("Expected object in result array");
+            }
+        }
+    } else {
+        panic!("Expected array result from without query");
+    }
+
+    // Cleanup
+    let db_drop_query = create_database_drop_query(database_name);
+    let db_drop_envelope = create_envelope(&format!("{query_id}-db-drop"), &db_drop_query);
+    let _db_drop_response = send_envelope_to_server(&mut stream, &db_drop_envelope).await;
+
+    println!("✅ Basic without test completed successfully");
+}
+
+#[tokio::test]
+async fn test_without_multiple_fields() {
+    let query_id = "test-without-multiple-001";
+    let database_name = &generate_unique_name("test_db_without_multiple");
+    let table_name = &generate_unique_name("test_table_without_multiple");
+
+    println!(
+        "Testing multiple fields without operation, ID: {query_id}, database: {database_name}, table: {table_name}"
+    );
+
+    // Connect to the running server
+    let mut stream = connect_to_server()
+        .await
+        .expect("Failed to connect to server. Make sure the server is running on 127.0.0.1:6090");
+
+    // Setup: Create database and table
+    let db_create_query = create_database_create_query(database_name);
+    let db_create_envelope = create_envelope(&format!("{query_id}-db-create"), &db_create_query);
+    let db_create_response = send_envelope_to_server(&mut stream, &db_create_envelope)
+        .await
+        .expect("Failed to send database create envelope");
+    validate_response_envelope(&db_create_response, &format!("{query_id}-db-create"))
+        .expect("Database create response validation failed");
+
+    let table_create_query = create_table_create_query(database_name, table_name);
+    let table_create_envelope =
+        create_envelope(&format!("{query_id}-table-create"), &table_create_query);
+    let table_create_response = send_envelope_to_server(&mut stream, &table_create_envelope)
+        .await
+        .expect("Failed to send table create envelope");
+    validate_response_envelope(&table_create_response, &format!("{query_id}-table-create"))
+        .expect("Table create response validation failed");
+
+    // Insert test data with many fields
+    let documents = vec![create_datum_object(vec![
+        ("id", create_string_datum("item1")),
+        ("title", create_string_datum("Product A")),
+        ("price", create_float_datum(29.99)),
+        ("cost", create_float_datum(15.50)),
+        ("internal_notes", create_string_datum("Check with supplier")),
+        ("category", create_string_datum("electronics")),
+    ])];
+
+    let insert_query = create_insert_query(database_name, table_name, documents);
+    let insert_envelope = create_envelope(&format!("{query_id}-insert"), &insert_query);
+    let insert_response = send_envelope_to_server(&mut stream, &insert_envelope)
+        .await
+        .expect("Failed to send insert envelope");
+    validate_response_envelope(&insert_response, &format!("{query_id}-insert"))
+        .expect("Insert response validation failed");
+
+    // Test without multiple fields (remove internal fields)
+    let without_query = create_without_query(
+        database_name,
+        table_name,
+        vec![
+            proto::FieldRef {
+                path: vec!["cost".to_string()],
+                separator: ".".to_string(),
+            },
+            proto::FieldRef {
+                path: vec!["internal_notes".to_string()],
+                separator: ".".to_string(),
+            },
+        ],
+    );
+
+    let without_envelope = create_envelope(&format!("{query_id}-without-multiple"), &without_query);
+    let without_response = send_envelope_to_server(&mut stream, &without_envelope)
+        .await
+        .expect("Failed to send without envelope");
+
+    let without_result =
+        decode_response_payload(&without_response).expect("Failed to decode without response");
+
+    // Verify the result structure
+    if let Some(proto::datum::Value::Array(array)) = &without_result.value {
+        assert_eq!(array.items.len(), 1, "Expected 1 document in result");
+
+        for doc in &array.items {
+            if let Some(proto::datum::Value::Object(obj)) = &doc.value {
+                // Internal fields should be removed
+                assert!(
+                    !obj.fields.contains_key("cost"),
+                    "Cost field should be removed"
+                );
+                assert!(
+                    !obj.fields.contains_key("internal_notes"),
+                    "Internal notes field should be removed"
+                );
+                // Public fields should remain
+                assert!(obj.fields.contains_key("id"), "ID field should remain");
+                assert!(
+                    obj.fields.contains_key("title"),
+                    "Title field should remain"
+                );
+                assert!(
+                    obj.fields.contains_key("price"),
+                    "Price field should remain"
+                );
+                assert!(
+                    obj.fields.contains_key("category"),
+                    "Category field should remain"
+                );
+            } else {
+                panic!("Expected object in result array");
+            }
+        }
+    } else {
+        panic!("Expected array result from without query");
+    }
+
+    // Cleanup
+    let db_drop_query = create_database_drop_query(database_name);
+    let db_drop_envelope = create_envelope(&format!("{query_id}-db-drop"), &db_drop_query);
+    let _db_drop_response = send_envelope_to_server(&mut stream, &db_drop_envelope).await;
+
+    println!("✅ Multiple fields without test completed successfully");
+}
+
+#[tokio::test]
+async fn test_without_nested_fields() {
+    let query_id = "test-without-nested-001";
+    let database_name = &generate_unique_name("test_db_without_nested");
+    let table_name = &generate_unique_name("test_table_without_nested");
+
+    println!(
+        "Testing nested fields without operation, ID: {query_id}, database: {database_name}, table: {table_name}"
+    );
+
+    // Connect to the running server
+    let mut stream = connect_to_server()
+        .await
+        .expect("Failed to connect to server. Make sure the server is running on 127.0.0.1:6090");
+
+    // Setup: Create database and table
+    let db_create_query = create_database_create_query(database_name);
+    let db_create_envelope = create_envelope(&format!("{query_id}-db-create"), &db_create_query);
+    let db_create_response = send_envelope_to_server(&mut stream, &db_create_envelope)
+        .await
+        .expect("Failed to send database create envelope");
+    validate_response_envelope(&db_create_response, &format!("{query_id}-db-create"))
+        .expect("Database create response validation failed");
+
+    let table_create_query = create_table_create_query(database_name, table_name);
+    let table_create_envelope =
+        create_envelope(&format!("{query_id}-table-create"), &table_create_query);
+    let table_create_response = send_envelope_to_server(&mut stream, &table_create_envelope)
+        .await
+        .expect("Failed to send table create envelope");
+    validate_response_envelope(&table_create_response, &format!("{query_id}-table-create"))
+        .expect("Table create response validation failed");
+
+    // Insert test data with nested structures
+    let profile_private = create_datum_object(vec![
+        ("ssn", create_string_datum("123-45-6789")),
+        ("phone", create_string_datum("555-1234")),
+    ]);
+
+    let profile = create_datum_object(vec![
+        ("bio", create_string_datum("Software developer")),
+        (
+            "private",
+            proto::Datum {
+                value: Some(proto::datum::Value::Object(profile_private)),
+            },
+        ),
+    ]);
+
+    let documents = vec![create_datum_object(vec![
+        ("id", create_string_datum("user1")),
+        ("name", create_string_datum("Alice")),
+        (
+            "profile",
+            proto::Datum {
+                value: Some(proto::datum::Value::Object(profile)),
+            },
+        ),
+    ])];
+
+    let insert_query = create_insert_query(database_name, table_name, documents);
+    let insert_envelope = create_envelope(&format!("{query_id}-insert"), &insert_query);
+    let insert_response = send_envelope_to_server(&mut stream, &insert_envelope)
+        .await
+        .expect("Failed to send insert envelope");
+    validate_response_envelope(&insert_response, &format!("{query_id}-insert"))
+        .expect("Insert response validation failed");
+
+    // Test without nested field (remove profile.private.ssn)
+    let without_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec![
+                "profile".to_string(),
+                "private".to_string(),
+                "ssn".to_string(),
+            ],
+            separator: ".".to_string(),
+        }],
+    );
+
+    let without_envelope = create_envelope(&format!("{query_id}-without-nested"), &without_query);
+    let without_response = send_envelope_to_server(&mut stream, &without_envelope)
+        .await
+        .expect("Failed to send without envelope");
+
+    let without_result =
+        decode_response_payload(&without_response).expect("Failed to decode without response");
+
+    // Verify the result structure
+    if let Some(proto::datum::Value::Array(array)) = &without_result.value {
+        assert_eq!(array.items.len(), 1, "Expected 1 document in result");
+
+        for doc in &array.items {
+            if let Some(proto::datum::Value::Object(obj)) = &doc.value {
+                assert!(
+                    obj.fields.contains_key("profile"),
+                    "Profile field should remain"
+                );
+
+                if let Some(proto::datum::Value::Object(profile_obj)) =
+                    &obj.fields.get("profile").unwrap().value
+                {
+                    assert!(
+                        profile_obj.fields.contains_key("private"),
+                        "Private field should remain"
+                    );
+
+                    if let Some(proto::datum::Value::Object(private_obj)) =
+                        &profile_obj.fields.get("private").unwrap().value
+                    {
+                        // SSN should be removed
+                        assert!(
+                            !private_obj.fields.contains_key("ssn"),
+                            "SSN field should be removed"
+                        );
+                        // Phone should remain
+                        assert!(
+                            private_obj.fields.contains_key("phone"),
+                            "Phone field should remain"
+                        );
+                    } else {
+                        panic!("Expected private object");
+                    }
+                } else {
+                    panic!("Expected profile object");
+                }
+            } else {
+                panic!("Expected object in result array");
+            }
+        }
+    } else {
+        panic!("Expected array result from without query");
+    }
+
+    // Cleanup
+    let db_drop_query = create_database_drop_query(database_name);
+    let db_drop_envelope = create_envelope(&format!("{query_id}-db-drop"), &db_drop_query);
+    let _db_drop_response = send_envelope_to_server(&mut stream, &db_drop_envelope).await;
+
+    println!("✅ Nested fields without test completed successfully");
+}
+
+#[tokio::test]
+async fn test_without_custom_separator() {
+    let query_id = "test-without-separator-001";
+    let database_name = &generate_unique_name("test_db_without_separator");
+    let table_name = &generate_unique_name("test_table_without_separator");
+
+    println!(
+        "Testing custom separator without operation, ID: {query_id}, database: {database_name}, table: {table_name}"
+    );
+
+    // Connect to the running server
+    let mut stream = connect_to_server()
+        .await
+        .expect("Failed to connect to server. Make sure the server is running on 127.0.0.1:6090");
+
+    // Setup: Create database and table
+    let db_create_query = create_database_create_query(database_name);
+    let db_create_envelope = create_envelope(&format!("{query_id}-db-create"), &db_create_query);
+    let db_create_response = send_envelope_to_server(&mut stream, &db_create_envelope)
+        .await
+        .expect("Failed to send database create envelope");
+    validate_response_envelope(&db_create_response, &format!("{query_id}-db-create"))
+        .expect("Database create response validation failed");
+
+    let table_create_query = create_table_create_query(database_name, table_name);
+    let table_create_envelope =
+        create_envelope(&format!("{query_id}-table-create"), &table_create_query);
+    let table_create_response = send_envelope_to_server(&mut stream, &table_create_envelope)
+        .await
+        .expect("Failed to send table create envelope");
+    validate_response_envelope(&table_create_response, &format!("{query_id}-table-create"))
+        .expect("Table create response validation failed");
+
+    // Insert test data with nested structures for custom separator testing
+    let credentials = create_datum_object(vec![
+        ("username", create_string_datum("admin")),
+        ("password", create_string_datum("secret123")),
+    ]);
+
+    let database_config = create_datum_object(vec![
+        ("host", create_string_datum("localhost")),
+        (
+            "credentials",
+            proto::Datum {
+                value: Some(proto::datum::Value::Object(credentials)),
+            },
+        ),
+    ]);
+
+    let documents = vec![create_datum_object(vec![
+        ("id", create_string_datum("config1")),
+        (
+            "database",
+            proto::Datum {
+                value: Some(proto::datum::Value::Object(database_config)),
+            },
+        ),
+    ])];
+
+    let insert_query = create_insert_query(database_name, table_name, documents);
+    let insert_envelope = create_envelope(&format!("{query_id}-insert"), &insert_query);
+    let insert_response = send_envelope_to_server(&mut stream, &insert_envelope)
+        .await
+        .expect("Failed to send insert envelope");
+    validate_response_envelope(&insert_response, &format!("{query_id}-insert"))
+        .expect("Insert response validation failed");
+
+    // Test with :: separator
+    let without_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec![
+                "database".to_string(),
+                "credentials".to_string(),
+                "password".to_string(),
+            ],
+            separator: "::".to_string(),
+        }],
+    );
+
+    let without_envelope =
+        create_envelope(&format!("{query_id}-without-separator"), &without_query);
+    let without_response = send_envelope_to_server(&mut stream, &without_envelope)
+        .await
+        .expect("Failed to send without envelope");
+
+    let without_result =
+        decode_response_payload(&without_response).expect("Failed to decode without response");
+
+    // Verify the result structure
+    if let Some(proto::datum::Value::Array(array)) = &without_result.value {
+        assert_eq!(array.items.len(), 1, "Expected 1 document in result");
+
+        for doc in &array.items {
+            if let Some(proto::datum::Value::Object(obj)) = &doc.value {
+                assert!(
+                    obj.fields.contains_key("database"),
+                    "Database field should remain"
+                );
+
+                if let Some(proto::datum::Value::Object(db_obj)) =
+                    &obj.fields.get("database").unwrap().value
+                {
+                    assert!(
+                        db_obj.fields.contains_key("credentials"),
+                        "Credentials field should remain"
+                    );
+
+                    if let Some(proto::datum::Value::Object(creds_obj)) =
+                        &db_obj.fields.get("credentials").unwrap().value
+                    {
+                        // Password should be removed
+                        assert!(
+                            !creds_obj.fields.contains_key("password"),
+                            "Password field should be removed"
+                        );
+                        // Username should remain
+                        assert!(
+                            creds_obj.fields.contains_key("username"),
+                            "Username field should remain"
+                        );
+                    } else {
+                        panic!("Expected credentials object");
+                    }
+                } else {
+                    panic!("Expected database object");
+                }
+            } else {
+                panic!("Expected object in result array");
+            }
+        }
+    } else {
+        panic!("Expected array result from without query");
+    }
+
+    // Cleanup
+    let db_drop_query = create_database_drop_query(database_name);
+    let db_drop_envelope = create_envelope(&format!("{query_id}-db-drop"), &db_drop_query);
+    let _db_drop_response = send_envelope_to_server(&mut stream, &db_drop_envelope).await;
+
+    println!("✅ Custom separator without test completed successfully");
+}
+
+#[tokio::test]
+async fn test_without_empty_table() {
+    let query_id = "test-without-empty-001";
+    let database_name = &generate_unique_name("test_db_without_empty");
+    let table_name = &generate_unique_name("test_table_without_empty");
+
+    println!(
+        "Testing without on empty table, ID: {query_id}, database: {database_name}, table: {table_name}"
+    );
+
+    // Connect to the running server
+    let mut stream = connect_to_server()
+        .await
+        .expect("Failed to connect to server. Make sure the server is running on 127.0.0.1:6090");
+
+    // Setup: Create database and table
+    let db_create_query = create_database_create_query(database_name);
+    let db_create_envelope = create_envelope(&format!("{query_id}-db-create"), &db_create_query);
+    let db_create_response = send_envelope_to_server(&mut stream, &db_create_envelope)
+        .await
+        .expect("Failed to send database create envelope");
+    validate_response_envelope(&db_create_response, &format!("{query_id}-db-create"))
+        .expect("Database create response validation failed");
+
+    let table_create_query = create_table_create_query(database_name, table_name);
+    let table_create_envelope =
+        create_envelope(&format!("{query_id}-table-create"), &table_create_query);
+    let table_create_response = send_envelope_to_server(&mut stream, &table_create_envelope)
+        .await
+        .expect("Failed to send table create envelope");
+    validate_response_envelope(&table_create_response, &format!("{query_id}-table-create"))
+        .expect("Table create response validation failed");
+
+    // Test without on empty table
+    let without_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec!["password".to_string()],
+            separator: ".".to_string(),
+        }],
+    );
+
+    let without_envelope = create_envelope(&format!("{query_id}-without-empty"), &without_query);
+    let without_response = send_envelope_to_server(&mut stream, &without_envelope)
+        .await
+        .expect("Failed to send without envelope");
+
+    let without_result =
+        decode_response_payload(&without_response).expect("Failed to decode without response");
+
+    // Verify the result structure
+    if let Some(proto::datum::Value::Array(array)) = &without_result.value {
+        assert_eq!(
+            array.items.len(),
+            0,
+            "Expected 0 documents in empty table result"
+        );
+    } else {
+        panic!("Expected array result from without query on empty table");
+    }
+
+    // Cleanup
+    let db_drop_query = create_database_drop_query(database_name);
+    let db_drop_envelope = create_envelope(&format!("{query_id}-db-drop"), &db_drop_query);
+    let _db_drop_response = send_envelope_to_server(&mut stream, &db_drop_envelope).await;
+
+    println!("✅ Empty table without test completed successfully");
+}
+
+#[test]
+fn test_without_query_creation() {
+    // Test that without query creation works correctly
+    let database_name = "test_db";
+    let table_name = "test_table";
+
+    // Test single field without
+    let single_field_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec!["password".to_string()],
+            separator: ".".to_string(),
+        }],
+    );
+
+    // Verify query structure
+    if let Some(proto::query::Kind::Without(without_op)) = &single_field_query.kind {
+        assert_eq!(without_op.fields.len(), 1);
+        assert_eq!(without_op.fields[0].path, vec!["password".to_string()]);
+        assert_eq!(without_op.fields[0].separator, ".");
+
+        // Verify source is a table query
+        if let Some(source) = &without_op.source {
+            if let Some(proto::query::Kind::Table(table)) = &source.kind {
+                assert_eq!(table.table.as_ref().unwrap().name, table_name);
+                assert_eq!(
+                    table
+                        .table
+                        .as_ref()
+                        .unwrap()
+                        .database
+                        .as_ref()
+                        .unwrap()
+                        .name,
+                    database_name
+                );
+            } else {
+                panic!("Expected table source");
+            }
+        } else {
+            panic!("Expected source");
+        }
+    } else {
+        panic!("Expected without query");
+    }
+
+    // Test multiple fields without
+    let multi_field_query = create_without_query(
+        database_name,
+        table_name,
+        vec![
+            proto::FieldRef {
+                path: vec!["password".to_string()],
+                separator: ".".to_string(),
+            },
+            proto::FieldRef {
+                path: vec!["ssn".to_string()],
+                separator: ".".to_string(),
+            },
+        ],
+    );
+
+    if let Some(proto::query::Kind::Without(without_op)) = &multi_field_query.kind {
+        assert_eq!(without_op.fields.len(), 2);
+        assert_eq!(without_op.fields[0].path, vec!["password".to_string()]);
+        assert_eq!(without_op.fields[1].path, vec!["ssn".to_string()]);
+    } else {
+        panic!("Expected without query");
+    }
+
+    // Test nested field without
+    let nested_field_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec![
+                "profile".to_string(),
+                "private".to_string(),
+                "ssn".to_string(),
+            ],
+            separator: ".".to_string(),
+        }],
+    );
+
+    if let Some(proto::query::Kind::Without(without_op)) = &nested_field_query.kind {
+        assert_eq!(without_op.fields.len(), 1);
+        assert_eq!(
+            without_op.fields[0].path,
+            vec![
+                "profile".to_string(),
+                "private".to_string(),
+                "ssn".to_string()
+            ]
+        );
+    } else {
+        panic!("Expected without query");
+    }
+
+    // Test custom separator
+    let custom_separator_query = create_without_query(
+        database_name,
+        table_name,
+        vec![proto::FieldRef {
+            path: vec![
+                "database".to_string(),
+                "credentials".to_string(),
+                "password".to_string(),
+            ],
+            separator: "::".to_string(),
+        }],
+    );
+
+    if let Some(proto::query::Kind::Without(without_op)) = &custom_separator_query.kind {
+        assert_eq!(without_op.fields.len(), 1);
+        assert_eq!(without_op.fields[0].separator, "::");
+        assert_eq!(
+            without_op.fields[0].path,
+            vec![
+                "database".to_string(),
+                "credentials".to_string(),
+                "password".to_string()
+            ]
+        );
+    } else {
+        panic!("Expected without query");
+    }
+
+    println!("✅ Without query creation test completed successfully");
+}


### PR DESCRIPTION
## Description

Implement `without` functionality to return all but the given set of fields from a document. This PR resolves: #10.

**Example usage:**

```ts
# Returns all results from a table
await r
  .db()
  .table('users')
  .without('id', 'name', 'address.country')
  .run(client);

# Returns a selection from a table
await r
  .table('orders')
  .getAll('01JYRXMJY8DJM44E1QWB3JYPB2', '01JYTGS113JBYNCSBDARZ5DSNQ')
  .without('id', 'name', 'address.country')
  .run(client)

# Returns a single result from a table
await r
  .table('orders')
  .get('01JYRXMJY8DJM44E1QWB3JYPB2')
  .without('id', 'name', 'address.country')
  .run(client)
```

## Testing instructions

1. Start RuloDB
2. Create a new TypeScript file with the content below
3. Execute the script and evaluate the results

<details>
<summary>Test script</summary>

```ts
import { Client, r } from "../sdk/typescript/src"; // <-- UPDATE AS NECESSARY

const client = new Client();
await client.connect();

type Order = {
  id: string;
  customer_id: string;
  quantity: number;
  price: number;
  address: {
    country: string;
  };
};

type OrderWithoutId = Omit<Order, "id">;
type OrderWithoutName = Omit<Order, "name">;

const orders: OrderWithoutId[] = [];
for (let i = 0; i < 1000; i++) {
  orders.push({
    customer_id: `customer-${i}`,
    quantity: Math.floor(Math.random() * 100),
    price: Math.floor(Math.random() * 1000),
    address: {
      country: Math.floor(Math.random() * 100) % 2 === 0 ? "USA" : "UAE",
    },
  });
}

const tables = await r.db().tableList().run(client);
if (!(await tables.toArray()).includes("orders")) {
  await r.db().tableCreate("orders").run(client);
}

const ordersTable = r.db().table<OrderWithoutId>("orders");

await ordersTable.insert(orders).run(client);

const result = await ordersTable
  .without<OrderWithoutName>("name")
  .run(client);

console.table(await result.toArray());

await client.disconnect();
```

</details>

## Checklist

- [x] I have read and understood the [Developer's Certificate of Origin] and
  added `Signed-off-by: <YOUR NAME>` to the commit trail where `<YOUR NAME>` is
  my name.

<!-- Links -->

[Developer's Certificate of Origin]: https://github.com/rulodb/rulodb/blob/main/CONTRIBUTING.md#developers-certificate-of-origin
